### PR TITLE
Fix missing gunicorn on Heroku

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,3 @@
 Flask
+gunicorn
+


### PR DESCRIPTION
## Summary
- add gunicorn to requirements so `Procfile` command works on Heroku

## Testing
- `python -m pip install -r requirements.txt`
- `python -m compileall -q app.py`


------
https://chatgpt.com/codex/tasks/task_e_687a5ebdafd483238653b8bdec4e585b